### PR TITLE
decoder: skip pixels with reference codeword 0

### DIFF
--- a/decoder/mf_rlefont.c
+++ b/decoder/mf_rlefont.c
@@ -183,7 +183,11 @@ static void write_ref_codeword(const struct mf_rlefont_s *font,
                                 struct renderstate_r *rstate,
                                 uint8_t code)
 {
-    if (code <= 15)
+    if (code == 0)
+    {
+        skip_pixels(rstate, 1);
+    }
+    else if (code <= 15)
     {
         write_pixels(rstate, 1, 0x11 * code);
     }


### PR DESCRIPTION
This prevents writing pixels with opacity 0 which can be a problem if
the pixel callback does not composite into the backbuffer.