### PR TITLE
Allow negative baseline_x

### DIFF
--- a/decoder/mf_font.h
+++ b/decoder/mf_font.h
@@ -36,7 +36,7 @@ struct mf_font_s
     uint8_t max_x_advance;
     
     /* Location of the text baseline relative to character. */
-    uint8_t baseline_x;
+    int8_t baseline_x;
     uint8_t baseline_y;
     
     /* Line height of the font (vertical advance). */


### PR DESCRIPTION
This correctly positions fonts with negative baseline_x. This can occur
when a filtered character set can crop all of its glyphs to the right of
the unmodified baseline_x.