### PR TITLE
Fix compile issue on Arch Linux/Manjaro

### DIFF
--- a/encoder/Makefile
+++ b/encoder/Makefile
@@ -6,8 +6,8 @@ ifneq ($(shell uname -s),Darwin)
 endif
 
 # Libfreetype
-CXXFLAGS += $(shell freetype-config --cflags)
-LDFLAGS += $(shell freetype-config --libs)
+CXXFLAGS += $(shell pkg-config freetype2 --cflags)
+LDFLAGS += $(shell pkg-config freetype2 --libs)
 
 # Class to represent font data internally
 OBJS = datafile.o


### PR DESCRIPTION
Hi there,

I've just found that the latest version of freetype on my Manjaro environment abandoned the `freetype-config`. As they said, we should use `pkg-config` instead. So here's a quick fix for that.

Here's the Arch Linux issue thread for your reference: https://bugs.archlinux.org/task/58447

Regards,
Jackson