### PR TITLE
encoder: add CMake & fix pkg-config for BSD/MinGW makefiles

### DIFF
--- a/encoder/.gitignore
+++ b/encoder/.gitignore
@@ -1,3 +1,7 @@
 mcufont
 unittests
 unittests.cc
+cmake-build-debug/
+build/
+.idea/
+.vscode/

--- a/encoder/CMakeLists.txt
+++ b/encoder/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.13)
+project(mfencoder)
+
+find_package(Freetype REQUIRED)
+find_package(Threads REQUIRED)
+include_directories(${FREETYPE_INCLUDE_DIRS})
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(.)
+
+add_executable(mfencoder
+        bdf_import.cc
+        bdf_import.hh
+        ccfixes.hh
+        datafile.cc
+        datafile.hh
+        encode_rlefont.cc
+        encode_rlefont.hh
+        export_bwfont.cc
+        export_bwfont.hh
+        export_rlefont.cc
+        export_rlefont.hh
+        exporttools.cc
+        exporttools.hh
+        freetype_import.cc
+        freetype_import.hh
+        gb2312_in_ucs2.h
+        importtools.cc
+        importtools.hh
+        main.cc
+        optimize_rlefont.cc
+        optimize_rlefont.hh)
+
+target_link_libraries(mfencoder ${FREETYPE_LIBRARIES} Threads::Threads)

--- a/encoder/Makefile.freebsd
+++ b/encoder/Makefile.freebsd
@@ -40,8 +40,8 @@ INCDIR      = .
 # Apply some magic where necessary                                             #
 ################################################################################
 
-CPPFLAGS    += $(shell freetype-config --cflags)
-LDFLAGS     += $(shell freetype-config --libs)
+CPPFLAGS    += $(shell pkg-config freetype2 --cflags)
+LDFLAGS     += $(shell pkg-config freetype2 --libs)
 OBJS        += $(addsuffix .o,$(basename $(CPPSRCS:%.cpp=%.o)))
 
 

--- a/encoder/Makefile.mingw32
+++ b/encoder/Makefile.mingw32
@@ -4,8 +4,8 @@ CXXFLAGS += -ggdb
 LDFLAGS += -pthread --static
 
 # Libfreetype
-CXXFLAGS += $(shell freetype-config --cflags)
-LDFLAGS += $(shell freetype-config --libs)
+CXXFLAGS += $(shell pkg-config freetype2 --cflags)
+LDFLAGS += $(shell pkg-config freetype2 --libs)
 #FREETYPE2_LIB = ../ugfx/3rdparty/freetype-2.6.1
 #CXXFLAGS += -I$(FREETYPE2_LIB)/include
 #LDFLAGS += -I$(FREETYPE2_LIB)/lib -lfreetype


### PR DESCRIPTION
Hi there,

I've just created a CMakeList for better IDE integrations (e.g. CLion or VSCode with CMake plugin). I have also fixed the `freetype-config` issue for BSD/MinGW makefiles (ref: https://github.com/mcufont/mcufont/pull/19).

Regards,
Jackson