### PR TITLE
decoder: use ARDUINO_ARCH_* 

### DIFF
--- a/decoder/mf_config.h
+++ b/decoder/mf_config.h
@@ -5,7 +5,7 @@
 
 #ifdef __AVR__
   #include <avr/pgmspace.h>
-#elif defined(ESP8266) || defined(ESP32)
+#elif defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
  #include <pgmspace.h>
 #else
  #include <stdint.h>


### PR DESCRIPTION
Hi there,

ESP32 does not have `pgmspace` and that wrapper is only available in Arduino for compatibility reasons. In this commit, if we just use the macro `ESP32` is probably fine. But it is a bit misleading as quite a few ESP32 developers like me only use pure ESP-IDF (Espressif's SDK) with no Arduino integrated. So we'd better use `ARDUINO_ARCH_ESP32` to avoid this issue.

Regards,
Jackson