### PR TITLE
decoder: GCC warning fixes

### DIFF
--- a/decoder/mf_font.c
+++ b/decoder/mf_font.c
@@ -115,7 +115,7 @@ const struct mf_font_s *mf_find_font(const char *name)
     return 0;
 }
 
-const struct mf_font_list_s *mf_get_font_list()
+const struct mf_font_list_s *mf_get_font_list(void)
 {
     return MF_INCLUDED_FONTS;
 }

--- a/decoder/mf_font.h
+++ b/decoder/mf_font.h
@@ -132,6 +132,6 @@ MF_EXTERN void mf_character_whitespace(const struct mf_font_s *font,
 MF_EXTERN const struct mf_font_s *mf_find_font(const char *name);
 
 /* Get the list of included fonts */
-MF_EXTERN const struct mf_font_list_s *mf_get_font_list();
+MF_EXTERN const struct mf_font_list_s *mf_get_font_list(void);
 
 #endif

--- a/decoder/mf_kerning.c
+++ b/decoder/mf_kerning.c
@@ -14,6 +14,7 @@ struct kerning_state_s
 static void fit_leftedge(int16_t x, int16_t y, uint8_t count, uint8_t alpha,
                          void *state)
 {
+    (void)count;
     struct kerning_state_s *s = state;
     
     if (alpha > 7)

--- a/decoder/mf_rlefont.c
+++ b/decoder/mf_rlefont.c
@@ -150,6 +150,7 @@ static void write_bin_codeword(const struct mf_rlefont_s *font,
                                 struct renderstate_r *rstate,
                                 uint8_t code)
 {
+    (void)font;
     uint8_t bitcount = fillentry_bitcount(code);
     uint8_t byte = code - DICT_START7BIT;
     uint8_t runlen = 0;


### PR DESCRIPTION
This PR fixes two types warnings when compiling with GCC:
- Two unused parameters in functions
- An old-style definition of `mf_get_font_list()`

This is purely cosmetic and should not change any behaviour of the code.