### PR TITLE
README: Specify language in the example listing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,9 @@ program for testing the decoder and renderer.
 The example fonts will be built in the *fonts* subfolder, and consist of two
 files each. For example, *DejaVuSans12.c* and *DejaVuSans12.h* are the
 DejaVu Sans font rendered at 12 pixels height. To render text using this
-font, you could do this::
+font, you could do this:
+
+.. code-block:: C
 
     #include "fonts.h"
     #include <mcufont.h>


### PR DESCRIPTION
This way GitHub renders the listing with the example with syntax highlighting for C code, see: https://github.com/mcufont/mcufont/blob/f6e4709b86184d435b01b6946670d3a2f82045f1/README.rst