### PR TITLE
Fix build on macOS

### DIFF
--- a/encoder/exporttools.cc
+++ b/encoder/exporttools.cc
@@ -96,14 +96,12 @@ int select_fallback_char(const DataFile &datafile)
 {
     std::set<int> chars;
 
-    size_t i = 0;
     for (const DataFile::glyphentry_t &g: datafile.GetGlyphTable())
     {
         for (size_t c: g.chars)
         {
             chars.insert(c);
         }
-        i++;
     }
 
     if (chars.count(0xFFFD))

--- a/fonts/Makefile
+++ b/fonts/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -f $(FONTS:=.c) $(FONTS:=.dat)
 
 fonts.h: $(FONTS:=.c)
-	/bin/echo -e $(foreach font,$(FONTS),'\n#include "'$(font)'.c"') > $@
+	printf '$(foreach font,$(FONTS),\n#include "$(font).c")\n' > $@
 
 %.c: %.dat $(MCUFONT)
 	$(MCUFONT) rlefont_export $<


### PR DESCRIPTION
On macOS 14.5, using Clang 15, compilation fails with the following error:
```
g++ -O2 -Wall -Werror -Wno-unused-function -Wno-sign-compare -std=c++0x -ggdb -I/opt/homebrew/include -I/opt/homebrew/opt/freetype/include/freetype2 -I/opt/homebrew/opt/libpng/include/libpng16 -c exporttools.cc
exporttools.cc:99:12: error: variable 'i' set but not used [-Werror,-Wunused-but-set-variable]
    size_t i = 0;
           ^
1 error generated.
make[1]: *** [exporttools.o] Error 1
make: *** [all] Error 2
```

After fixing this error there is another. The `fonts/fonts.h` file is generated with the following content:
```
-e \n#include "DejaVuSans12.c" \n#include "DejaVuSans12bw.c" \n#include "DejaVuSerif16.c" \n#include "DejaVuSerif32.c" \n#include "fixed_5x8.c" \n#include "fixed_7x14.c" \n#include "fixed_10x20.c" \n#include "DejaVuSans12bw_bwfont.c"
```

This results in another compilation error:
```
make -C render_bmp
cc -O0 -Wall -Werror -ansi -ggdb -I ../../fonts -I ../../decoder -o render_bmp render_bmp.c write_bmp.c ../../decoder/mf_encoding.c ../../decoder/mf_font.c ../../decoder/mf_justify.c ../../decoder/mf_kerning.c ../../decoder/mf_rlefont.c ../../decoder/mf_bwfont.c ../../decoder/mf_scaledfont.c ../../decoder/mf_wordwrap.c
In file included from ../../decoder/mf_font.c:8:
../../fonts/fonts.h:1:1: error: expected external declaration
-e \n#include "DejaVuSans12.c" \n#include "DejaVuSans12bw.c" \n#include "DejaVuSerif16.c" \n#include "DejaVuSerif32.c" \n#include "fixed_5x8.c" \n#include "fixed_7x14.c" \n#include "fixed_10x20.c" \n#include "DejaVuSans12bw_bwfont.c"
^
../../fonts/fonts.h:1:2: error: unknown type name 'e'
-e \n#include "DejaVuSans12.c" \n#include "DejaVuSans12bw.c" \n#include "DejaVuSerif16.c" \n#include "DejaVuSerif32.c" \n#include "fixed_5x8.c" \n#include "fixed_7x14.c" \n#include "fixed_10x20.c" \n#include "DejaVuSans12bw_bwfont.c"
 ^
../../fonts/fonts.h:1:4: error: expected identifier or '('
-e \n#include "DejaVuSans12.c" \n#include "DejaVuSans12bw.c" \n#include "DejaVuSerif16.c" \n#include "DejaVuSerif32.c" \n#include "fixed_5x8.c" \n#include "fixed_7x14.c" \n#include "fixed_10x20.c" \n#include "DejaVuSans12bw_bwfont.c"
   ^
3 errors generated.
make[2]: *** [render_bmp] Error 1
```

This PR fixes both of these issues.